### PR TITLE
Exclude testTslint from build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,15 +7,9 @@
         "noUnusedLocals": true,
         "forceConsistentCasingInFileNames": true,
         "removeComments": true,
-        "lib": [
-            "es2016"
-        ],
+        "lib": ["es2016"],
         "sourceMap": true,
         "rootDir": "."
     },
-    "exclude": [
-        "node_modules",
-        ".vscode-test",
-        "testProject"
-    ]
+    "exclude": ["node_modules", ".vscode-test", "testProject", "testTslint"]
 }


### PR DESCRIPTION
small nit to ignore `testTslint` while building.